### PR TITLE
Fix wrong application type in RemoveAttributeSet

### DIFF
--- a/src/main/java/io/vlingo/cluster/model/ClusterConfiguration.java
+++ b/src/main/java/io/vlingo/cluster/model/ClusterConfiguration.java
@@ -36,6 +36,7 @@ public class ClusterConfiguration implements Configuration {
     return Collections.unmodifiableSet(nodes);
   }
 
+  // Currently not used
   @Override
   public Set<Node> allNodesOf(final Collection<Id> ids) {
     final Set<Node> nodes = new TreeSet<Node>();

--- a/src/main/java/io/vlingo/cluster/model/attribute/message/RemoveAttributeSet.java
+++ b/src/main/java/io/vlingo/cluster/model/attribute/message/RemoveAttributeSet.java
@@ -18,7 +18,7 @@ public class RemoveAttributeSet extends ApplicationMessage {
   }
   
   public RemoveAttributeSet(final Node node, final AttributeSet set) {
-    super(NoCorrelatingMessageId, ApplicationMessageType.RemoveAttributeSet, trackingId(node, ApplicationMessageType.CreateAttributeSet, set.name));
+    super(NoCorrelatingMessageId, ApplicationMessageType.RemoveAttributeSet, trackingId(node, ApplicationMessageType.RemoveAttributeSet, set.name));
     
     this.attributeSetName = set.name;
   }


### PR DESCRIPTION
Fixing wrong type in RemoveAttributeSet and add unused comment on `allNodesOff` method in `ClusterConfiguration` class.