### PR TITLE
replace JDKLogger.testInstance() with LoggerProvider.noOpLoggerProvid…

### DIFF
--- a/src/test/java/io/vlingo/cluster/model/AbstractMessageTool.java
+++ b/src/test/java/io/vlingo/cluster/model/AbstractMessageTool.java
@@ -7,15 +7,15 @@
 
 package io.vlingo.cluster.model;
 
-import java.nio.ByteBuffer;
-
-import io.vlingo.actors.plugin.logging.jdk.JDKLogger;
+import io.vlingo.actors.LoggerProvider;
 import io.vlingo.wire.message.Converters;
 import io.vlingo.wire.message.RawMessage;
 import io.vlingo.wire.node.Configuration;
 
+import java.nio.ByteBuffer;
+
 public class AbstractMessageTool {
-  protected Configuration config = new ClusterConfiguration(JDKLogger.testInstance());
+  protected Configuration config = new ClusterConfiguration(LoggerProvider.noOpLoggerProvider().logger());
   
   public RawMessage buildRawMessageBuffer(final ByteBuffer buffer, final String message) {
     buffer.clear();


### PR DESCRIPTION
`AbstractMessageTool` in `vlingo-cluster` references `JDKLogger` which no longer exists, resulting in compilation errors. Replaced `JDKLogger.testInstance()` with `LoggerProvider.noOpLoggerProvider().logger()`