### PR TITLE
removes ApplicationOutboundStream parameter from handleApplicationMessage

### DIFF
--- a/src/main/java/io/vlingo/cluster/model/Cluster.java
+++ b/src/main/java/io/vlingo/cluster/model/Cluster.java
@@ -25,9 +25,7 @@ public class Cluster {
   public static final synchronized Tuple2<ClusterSnapshotControl, Logger> controlFor(
           final ClusterApplicationInstantiator<?> instantiator,
           final Properties properties,
-          final String nodeName)
-  throws Exception {
-
+          final String nodeName) {
     if (world != null) {
       throw new IllegalArgumentException("Cluster snapshot control already exists.");
     }
@@ -38,19 +36,7 @@ public class Cluster {
           final World world,
           final ClusterApplicationInstantiator<?> instantiator,
           final Properties properties,
-          final String nodeName)
-  throws Exception {
-    return controlFor(world, world.stage(), instantiator, properties, nodeName);
-  }
-
-  public static final synchronized Tuple2<ClusterSnapshotControl, Logger> controlFor(
-          final World world,
-          final Stage stage,
-          final ClusterApplicationInstantiator<?> instantiator,
-          final Properties properties,
-          final String nodeName)
-  throws Exception {
-
+          final String nodeName) {
     if (control.get() != null) {
       throw new IllegalArgumentException("Cluster snapshot control already exists.");
     }

--- a/src/main/java/io/vlingo/cluster/model/ClusterApplicationBroadcaster.java
+++ b/src/main/java/io/vlingo/cluster/model/ClusterApplicationBroadcaster.java
@@ -10,7 +10,6 @@ package io.vlingo.cluster.model;
 import io.vlingo.actors.Logger;
 import io.vlingo.cluster.model.application.ClusterApplication;
 import io.vlingo.cluster.model.attribute.AttributesProtocol;
-import io.vlingo.wire.fdx.outbound.ApplicationOutboundStream;
 import io.vlingo.wire.message.RawMessage;
 import io.vlingo.wire.node.Id;
 import io.vlingo.wire.node.Node;
@@ -135,7 +134,7 @@ class ClusterApplicationBroadcaster implements ClusterApplication {
   }
 
   @Override
-  public void handleApplicationMessage(final RawMessage message, final ApplicationOutboundStream responder) {
+  public void handleApplicationMessage(final RawMessage message) {
   }
 
   private void broadcast(final Consumer<ClusterApplication> inform) {

--- a/src/main/java/io/vlingo/cluster/model/ClusterSnapshotActor.java
+++ b/src/main/java/io/vlingo/cluster/model/ClusterSnapshotActor.java
@@ -124,7 +124,7 @@ public class ClusterSnapshotActor
         logger().warn("ClusterSnapshot received invalid raw message '{}'", textMessage);
       }
     } else if (addressType.isApplication()) {
-      clusterApplication.handleApplicationMessage(message, communicationsHub.applicationOutboundStream()); // TODO
+      clusterApplication.handleApplicationMessage(message); // TODO
     } else {
       logger().warn(
               "ClusterSnapshot couldn't dispatch incoming message; unknown address type: " +

--- a/src/main/java/io/vlingo/cluster/model/ClusterSnapshotControl.java
+++ b/src/main/java/io/vlingo/cluster/model/ClusterSnapshotControl.java
@@ -38,6 +38,7 @@ public interface ClusterSnapshotControl {
 
     final ClusterSnapshotInitializer initializer = new ClusterSnapshotInitializer(nodeName, properties, world.defaultLogger());
     instantiator.node(initializer.localNode());
+    instantiator.hub(initializer.communicationsHub());
 
     final ClusterApplication application = ClusterApplication.instance(stage, instantiator);
 

--- a/src/main/java/io/vlingo/cluster/model/application/ClusterApplication.java
+++ b/src/main/java/io/vlingo/cluster/model/application/ClusterApplication.java
@@ -16,6 +16,7 @@ import io.vlingo.actors.Stage;
 import io.vlingo.actors.Startable;
 import io.vlingo.actors.Stoppable;
 import io.vlingo.actors.World;
+import io.vlingo.cluster.model.CommunicationsHub;
 import io.vlingo.cluster.model.Properties;
 import io.vlingo.cluster.model.attribute.AttributesProtocol;
 import io.vlingo.wire.message.RawMessage;
@@ -44,11 +45,20 @@ public interface ClusterApplication extends Startable, Stoppable {
   }
 
   static abstract class ClusterApplicationInstantiator<A extends Actor> implements ActorInstantiator<A> {
+    private CommunicationsHub hub;
     private Node node;
     private final Class<A> type;
 
     public ClusterApplicationInstantiator(final Class<A> type) {
       this.type = type;
+    }
+
+    public CommunicationsHub hub() {
+      return this.hub;
+    }
+
+    public void hub(final CommunicationsHub hub) {
+      this.hub = hub;
     }
 
     public Node node() {

--- a/src/main/java/io/vlingo/cluster/model/application/ClusterApplication.java
+++ b/src/main/java/io/vlingo/cluster/model/application/ClusterApplication.java
@@ -18,7 +18,6 @@ import io.vlingo.actors.Stoppable;
 import io.vlingo.actors.World;
 import io.vlingo.cluster.model.Properties;
 import io.vlingo.cluster.model.attribute.AttributesProtocol;
-import io.vlingo.wire.fdx.outbound.ApplicationOutboundStream;
 import io.vlingo.wire.message.RawMessage;
 import io.vlingo.wire.node.Id;
 import io.vlingo.wire.node.Node;
@@ -77,7 +76,7 @@ public interface ClusterApplication extends Startable, Stoppable {
     }
   }
 
-  void handleApplicationMessage(final RawMessage message, final ApplicationOutboundStream responder);
+  void handleApplicationMessage(final RawMessage message);
 
   void informAllLiveNodes(final Collection<Node> liveNodes, final boolean isHealthyCluster);
   void informLeaderElected(final Id leaderId, final boolean isHealthyCluster, final boolean isLocalNodeLeading);

--- a/src/main/java/io/vlingo/cluster/model/application/ClusterApplicationAdapter.java
+++ b/src/main/java/io/vlingo/cluster/model/application/ClusterApplicationAdapter.java
@@ -10,7 +10,6 @@ package io.vlingo.cluster.model.application;
 import java.util.Collection;
 
 import io.vlingo.cluster.model.attribute.AttributesProtocol;
-import io.vlingo.wire.fdx.outbound.ApplicationOutboundStream;
 import io.vlingo.wire.message.RawMessage;
 import io.vlingo.wire.node.Id;
 import io.vlingo.wire.node.Node;
@@ -33,7 +32,7 @@ public abstract class ClusterApplicationAdapter extends ClusterApplicationActor 
   }
 
   @Override
-  public void handleApplicationMessage(final RawMessage message, final ApplicationOutboundStream responder) {
+  public void handleApplicationMessage(final RawMessage message) {
   }
 
   @Override

--- a/src/main/java/io/vlingo/cluster/model/application/FakeClusterApplicationActor.java
+++ b/src/main/java/io/vlingo/cluster/model/application/FakeClusterApplicationActor.java
@@ -9,7 +9,6 @@ package io.vlingo.cluster.model.application;
 
 import io.vlingo.cluster.model.attribute.Attribute;
 import io.vlingo.cluster.model.attribute.AttributesProtocol;
-import io.vlingo.wire.fdx.outbound.ApplicationOutboundStream;
 import io.vlingo.wire.message.RawMessage;
 import io.vlingo.wire.node.Id;
 import io.vlingo.wire.node.Node;
@@ -30,7 +29,7 @@ public class FakeClusterApplicationActor extends ClusterApplicationAdapter {
   }
 
   @Override
-  public void handleApplicationMessage(final RawMessage message, final ApplicationOutboundStream responder) {
+  public void handleApplicationMessage(final RawMessage message) {
      logger().debug("APP: Received application message: " + message.asTextMessage());
   }
 

--- a/src/test/java/io/vlingo/cluster/model/MockClusterApplication.java
+++ b/src/test/java/io/vlingo/cluster/model/MockClusterApplication.java
@@ -12,7 +12,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import io.vlingo.cluster.model.application.ClusterApplication;
 import io.vlingo.cluster.model.attribute.AttributesProtocol;
-import io.vlingo.wire.fdx.outbound.ApplicationOutboundStream;
 import io.vlingo.wire.message.RawMessage;
 import io.vlingo.wire.node.Id;
 import io.vlingo.wire.node.Node;
@@ -63,7 +62,7 @@ public class MockClusterApplication implements ClusterApplication {
   }
 
   @Override
-  public void handleApplicationMessage(RawMessage message, ApplicationOutboundStream responder) {
+  public void handleApplicationMessage(RawMessage message) {
     handleApplicationMessage.incrementAndGet();
   }
 


### PR DESCRIPTION
A `ClusterApplication` would know where to send messages to at the time of its creation.